### PR TITLE
Fix DatabaseConnectionService invalid config test

### DIFF
--- a/tests/Services/DatabaseConnectionServiceTest.php
+++ b/tests/Services/DatabaseConnectionServiceTest.php
@@ -20,14 +20,13 @@ class DatabaseConnectionServiceTest extends TestCase
 
 
     /**
-     * @doesNotPerformAssertions
      * @throws Exception
      */
     public function testCreateConnectionInvalidConfig()
     {
         $this->expectException(\LogicException::class);
-        $configFilePath = '/path/does/not/need/to/exist/for/test.yml';
-        $service = $this->createMock(DatabaseConnectionService::class);
+        $configFilePath = '/path/that/does/not/exist.yml';
+        $service = new DatabaseConnectionService();
         $service->setConfigFilePath($configFilePath);
         $service->createConnection();
     }


### PR DESCRIPTION
## Summary
- update DatabaseConnectionService invalid config test

## Testing
- `./vendor/bin/phpunit tests/Services/DatabaseConnectionServiceTest.php` *(fails: No such file or directory)*